### PR TITLE
Enable termination of SPARE-* computation

### DIFF
--- a/QtBrainChartGUI/plugins/computeSPAREs/computeSPAREs.ui
+++ b/QtBrainChartGUI/plugins/computeSPAREs/computeSPAREs.ui
@@ -76,6 +76,12 @@
          <property name="text">
           <string>Compute SPARE-*</string>
          </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
This should properly terminate the computation of the SPARE-* scores.

Fix #117 